### PR TITLE
More rectangle functions, more `@safe`, and default values of `Camera2D`

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,19 +5,19 @@
 	"authors": [
 		"ONROUNDIT"
 	],
-        "configurations" : [
-            {
-                "name": "library"
-            },
-            {
-                "name": "unittest",
-                "versions" : ["raylib_test"],
-                "libs" : ["raylib"],
-                "lflags-posix": ["-L."],
-                "lflags-osx": ["-rpath", "@executable_path/"],
-                "lflags-linux" : ["-rpath=$$ORIGIN"]
-            }
-        ],
+    "configurations" : [
+        {
+            "name": "library"
+        },
+        {
+            "name": "unittest",
+            "versions" : ["raylib_test"],
+            "libs" : ["raylib"],
+            "lflags-posix": ["-L."],
+            "lflags-osx": ["-rpath", "@executable_path/"],
+            "lflags-linux" : ["-rpath=$$ORIGIN"]
+        }
+    ],
 	"copyright": "Copyright (c) Ramon Santamaria (@raysan5), Petro Romanovych (@onroundit), Jan Hoenig (@m3m0ry), Steven Schveighoffer (@schveiguy), Liam McGillivray (@LiamM32)",
         "excludedSourceFiles": ["source/rlgl.d", "source/raymath.d", "source/easings.d", "source/raymathext.d", "source/raylib_types.d"],
 	"targetType": "sourceLibrary",

--- a/source/raylib/package.d
+++ b/source/raylib/package.d
@@ -270,15 +270,6 @@ struct Camera3D
 
 alias Camera = Camera3D; // Camera type fallback, defaults to Camera3D
 
-// Camera2D, defines position/orientation in 2d space
-struct Camera2D
-{
-    Vector2 offset; // Camera offset (displacement from target)
-    Vector2 target; // Camera target (rotation and zoom origin)
-    float rotation; // Camera rotation in degrees
-    float zoom; // Camera zoom (scaling), should be 1.0f by default
-}
-
 // Mesh, vertex data and vao/vbo
 struct Mesh
 {

--- a/source/raylib/raylib_types.d
+++ b/source/raylib/raylib_types.d
@@ -2,6 +2,7 @@
 module raylib.raylib_types;
 
 import raylib;
+debug import std.stdio;
 
 // Vector2 type
 struct Vector2
@@ -52,6 +53,30 @@ struct Matrix
     float m7 = 0.0f;
     float m11 = 0.0f;
     float m15 = 0.0f;
+}
+
+// Camera2D, defines position/orientation in 2d space
+struct Camera2D
+{
+    version (enhancedD) {
+        Vector2 offset; // Camera offset (displacement from target)
+        Vector2 target; // Camera target (rotation and zoom origin)
+        float rotation; // Camera rotation in degrees
+        float zoom; // Camera zoom (scaling), should be 1.0f by default
+
+        this() {initialize(); return this;}
+    } else {
+        Vector2 offset; // Camera offset (displacement from target)
+        Vector2 target; // Camera target (rotation and zoom origin)
+        float rotation; // Camera rotation in degrees
+        float zoom; // Camera zoom (scaling), should be 1.0f by default
+    }
+    
+    void initialize() {
+        this.zoom = 1.0f;
+        if (IsWindowReady) offset = Vector2(GetScreenWidth/2.0f, GetScreenHeight/2.0f);
+        else debug writeln("Didn't initialize camera offset, as Window isn't open.");
+    }
 }
 
 // Rectangle type

--- a/source/raylib/raylib_types.d
+++ b/source/raylib/raylib_types.d
@@ -4,6 +4,11 @@ module raylib.raylib_types;
 import raylib;
 debug import std.stdio;
 
+version (enhancedD) const ED = true;
+else const ED = false;
+
+@safe:
+
 // Vector2 type
 struct Vector2
 {
@@ -58,25 +63,12 @@ struct Matrix
 // Camera2D, defines position/orientation in 2d space
 struct Camera2D
 {
-    version (enhancedD) {
-        Vector2 offset; // Camera offset (displacement from target)
-        Vector2 target; // Camera target (rotation and zoom origin)
-        float rotation; // Camera rotation in degrees
-        float zoom; // Camera zoom (scaling), should be 1.0f by default
 
-        this() {initialize(); return this;}
-    } else {
-        Vector2 offset; // Camera offset (displacement from target)
-        Vector2 target; // Camera target (rotation and zoom origin)
-        float rotation; // Camera rotation in degrees
-        float zoom; // Camera zoom (scaling), should be 1.0f by default
-    }
-    
-    void initialize() {
-        this.zoom = 1.0f;
-        if (IsWindowReady) offset = Vector2(GetScreenWidth/2.0f, GetScreenHeight/2.0f);
-        else debug writeln("Didn't initialize camera offset, as Window isn't open.");
-    }
+    Vector2 offset; // Camera offset (displacement from target)
+    Vector2 target; // Camera target (rotation and zoom origin)
+    float rotation; // Camera rotation in degrees
+    // Warning: In Raylib, & previous versions of Raylib-D, `zoom` is initially `0.0f`.
+    float zoom = 1f; // Camera zoom (scaling), should be 1.0f by default
 }
 
 // Rectangle type
@@ -88,6 +80,11 @@ struct Rectangle
     float height;
     alias w = width;
     alias h = height;
+
+    float top() {return y;}
+    float bottom() {return y + height;}
+    float left() {return x;}
+    float right() {return x + width;}
 
     Vector2 origin() { // Rectangle function exclusive to raylib-d
         return Vector2(x, y);
@@ -127,6 +124,8 @@ struct Rectangle
         result.opOpAssign!op(offset);
         return result;
     }
+
+    Vector2 opCast(T)() if (is(T==Vector2)) => origin();
 }
 
 enum Colors


### PR DESCRIPTION
These are the changes:

- `dub.json` now says to include `raylib`, as Raylib-D isn't usable without it.
- More functions added to `Rectangle`, including `top`, `bottom`, `left`, and `right`.
- Rectangle functions marked `@safe`.
- `Camera2D.zoom` set to `1.0f` by default. This would make it easy to figure-out how to use.

I think it makes sense for `Camera2D.zoom` to be set to `1.0f` by default, because that is what it is usually set to straight away. The documentation for Raylib even says that it should be set to `1.0f` by default, which a new D programmer not experienced in C may interpret this to mean that it *is* set to `1.0f` by default.

Let's just hope that there aren't any projects out there that use the value of `Camera2D.zoom` to detect whether a camera has been initialized, as that would result in a breaking change here. However, I think it's unlikely that there are any programs that do that. I considered having an "enhancedD" configuration that would set things to be more D-like while keeping the default configuration to be in-line with Raylib. However, I decided to drop this idea as a new user of Raylib-D probably wouldn't think to set this configuration when starting a new project.