### PR TITLE
Update to raylib 5.5-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use `dub add` to add raylib-d to the dependency list of an existing project:
 
 ```sh
 > dub add raylib-d
-Adding dependency raylib-d ~>4.2.3
+Adding dependency raylib-d ~>5.0.1
 >
 ```
 
@@ -28,7 +28,7 @@ You will need a copy of the raylib binary C library to link against, in order to
 
 ### *NEW* Method 1: install appropriate raylib library with helper tool
 
-In version 4.2.1 of raylib-d, a new subproject `raylib-d:install` is included, along with pre-built binary libraries of raylib. This greatly simplifies the process of obtaining pre-built libraries. Note that this is a *work in progress* and not every binary distribution is included.
+In raylib-d version 4.2.1 onwards, a new `raylib-d:install` subproject is included, along with pre-built binary raylib libraries. This greatly simplifies the process of obtaining pre-built libraries. Note that this is a *work in progress* and not all binary distributions are included.
 
 To run this, run this command from your project directory, and it will copy all the appropriate library files to your project directory:
 
@@ -43,7 +43,7 @@ The following OS/arch combinations are included:
 * MacOS - x86_64
 * MacOS - arm64
 
-If you do not have one of these systems, or want to use static linking, please use a different method.
+If you do not have one of these systems (e.g. FreeBSD), or want to use static linking, please use a different method.
 
 If other platforms are desired, please let me know in the issues. As of now, I am only supporting libraries that I built myself or that are included in the official distribution.
 
@@ -88,7 +88,7 @@ You must include the linker flags to link against the raylib library in your dub
 The following directives should work for all systems, for the case where the library is in the project directory.
 
 ```json
-"dependencies": { "raylib-d": "~>4.2.0" },
+"dependencies": { "raylib-d": "~>5.0.1" },
 "libs": [ "raylib" ],
 "lflags-posix" : ["-L."],
 "lflags-osx" : ["-rpath", "@executable_path/"],

--- a/dub.json
+++ b/dub.json
@@ -1,27 +1,46 @@
 {
-	"name": "raylib-d",
-	"description": "D binding for Raylib",
-	"license": "Zlib",
 	"authors": [
 		"ONROUNDIT"
 	],
-        "configurations" : [
-            {
-                "name": "library"
-            },
-            {
-                "name": "unittest",
-                "versions" : ["raylib_test"],
-                "libs" : ["raylib"],
-                "lflags-posix": ["-L."],
-                "lflags-osx": ["-rpath", "@executable_path/"],
-                "lflags-linux" : ["-rpath=$$ORIGIN"]
-            }
-        ],
+	"configurations": [
+		{
+			"name": "library",
+			"targetType": "sourceLibrary"
+		},
+		{
+			"lflags-linux": [
+				"-rpath=$$ORIGIN"
+			],
+			"lflags-osx": [
+				"-rpath",
+				"@executable_path/"
+			],
+			"lflags-posix": [
+				"-L."
+			],
+			"libs": [
+				"raylib"
+			],
+			"name": "unittest",
+			"targetType": "sourceLibrary",
+			"versions": [
+				"raylib_test"
+			]
+		}
+	],
 	"copyright": "Copyright (c) Ramon Santamaria (@raysan5), Petro Romanovych (@onroundit), Jan Hoenig (@m3m0ry), Steven Schveighoffer (@schveiguy), Liam McGillivray (@LiamM32)",
-        "excludedSourceFiles": ["source/rlgl.d", "source/raymath.d", "source/easings.d", "source/raymathext.d", "source/raylib_types.d"],
-	"targetType": "sourceLibrary",
-        "subPackages" : [
-            "install"
-        ]
+	"description": "D binding for Raylib",
+	"excludedSourceFiles": [
+		"source/rlgl.d",
+		"source/raymath.d",
+		"source/easings.d",
+		"source/raymathext.d",
+		"source/raylib_types.d"
+	],
+	"license": "Zlib",
+	"name": "raylib-d",
+	"subPackages": [
+		"install"
+	],
+	"targetType": "sourceLibrary"
 }

--- a/dub.json
+++ b/dub.json
@@ -1,46 +1,27 @@
 {
+	"name": "raylib-d",
+	"description": "D binding for Raylib",
+	"license": "Zlib",
 	"authors": [
 		"ONROUNDIT"
 	],
-	"configurations": [
-		{
-			"name": "library",
-			"targetType": "sourceLibrary"
-		},
-		{
-			"lflags-linux": [
-				"-rpath=$$ORIGIN"
-			],
-			"lflags-osx": [
-				"-rpath",
-				"@executable_path/"
-			],
-			"lflags-posix": [
-				"-L."
-			],
-			"libs": [
-				"raylib"
-			],
-			"name": "unittest",
-			"targetType": "sourceLibrary",
-			"versions": [
-				"raylib_test"
-			]
-		}
-	],
+        "configurations" : [
+            {
+                "name": "library"
+            },
+            {
+                "name": "unittest",
+                "versions" : ["raylib_test"],
+                "libs" : ["raylib"],
+                "lflags-posix": ["-L."],
+                "lflags-osx": ["-rpath", "@executable_path/"],
+                "lflags-linux" : ["-rpath=$$ORIGIN"]
+            }
+        ],
 	"copyright": "Copyright (c) Ramon Santamaria (@raysan5), Petro Romanovych (@onroundit), Jan Hoenig (@m3m0ry), Steven Schveighoffer (@schveiguy), Liam McGillivray (@LiamM32)",
-	"description": "D binding for Raylib",
-	"excludedSourceFiles": [
-		"source/rlgl.d",
-		"source/raymath.d",
-		"source/easings.d",
-		"source/raymathext.d",
-		"source/raylib_types.d"
-	],
-	"license": "Zlib",
-	"name": "raylib-d",
-	"subPackages": [
-		"install"
-	],
-	"targetType": "sourceLibrary"
+        "excludedSourceFiles": ["source/rlgl.d", "source/raymath.d", "source/easings.d", "source/raymathext.d", "source/raylib_types.d"],
+	"targetType": "sourceLibrary",
+        "subPackages" : [
+            "install"
+        ]
 }

--- a/install/dub.json
+++ b/install/dub.json
@@ -11,5 +11,5 @@
     "description": "Install raylib binary files",
     "license": "boost-1.0",
     "name": "install",
-    "targetType": "executable"
+    "targetType": "executable",
 }

--- a/install/dub.json
+++ b/install/dub.json
@@ -10,5 +10,6 @@
     },
     "description": "Install raylib binary files",
     "license": "boost-1.0",
-    "name": "install"
+    "name": "install",
+    "targetType": "executable"
 }

--- a/install/dub.json
+++ b/install/dub.json
@@ -4,9 +4,9 @@
     ],
     "copyright": "Copyright © 2022-2023, Steven Schveighoffer",
     "dependencies": {
-        "jsoniopipe": "~>0.2.5",
-        "iopipe": "~>0.2.4",
-        "io": "~>0.3.4"
+        "jsoniopipe": "~>0.2.7",
+        "iopipe": "~>0.2.5",
+        "io": "~>0.3.5"
     },
     "description": "Install raylib binary files",
     "license": "boost-1.0",

--- a/source/raylib/raymath.d
+++ b/source/raylib/raymath.d
@@ -33,7 +33,7 @@ import raylib;
 *
 *   LICENSE: zlib/libpng
 *
-*   Copyright (c) 2015-2023 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
 *
 *   This software is provided "as-is", without any express or implied warranty. In no event
 *   will the authors be held liable for any damages arising from the use of this software.
@@ -56,7 +56,9 @@ extern (C) @nogc nothrow:
 
 // Function specifiers definition
 
-// We are building raylib as a Win32 shared library (.dll).
+// We are building raylib as a Win32 shared library (.dll)
+
+// We are building raylib as a Unix shared library (.so/.dylib)
 
 // We are using raylib as a Win32 shared library (.dll)
 
@@ -122,7 +124,7 @@ struct float16
     float[16] v;
 }
 
-// Required for: sinf(), cosf(), tan(), atan2f(), sqrtf(), floor(), fminf(), fmaxf(), fabs()
+// Required for: sinf(), cosf(), tan(), atan2f(), sqrtf(), floor(), fminf(), fmaxf(), fabsf()
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Utils math
@@ -225,6 +227,12 @@ Vector2 Vector2Lerp(Vector2 v1, Vector2 v2, float amount);
 // Dot product
 Vector2 Vector2Reflect(Vector2 v, Vector2 normal);
 
+// Get min value for each pair of components
+Vector2 Vector2Min(Vector2 v1, Vector2 v2);
+
+// Get max value for each pair of components
+Vector2 Vector2Max(Vector2 v1, Vector2 v2);
+
 // Rotate vector by angle
 Vector2 Vector2Rotate(Vector2 v, float angle);
 
@@ -239,10 +247,19 @@ Vector2 Vector2Invert(Vector2 v);
 Vector2 Vector2Clamp(Vector2 v, Vector2 min, Vector2 max);
 
 // Clamp the magnitude of the vector between two min and max values
+
+// By default, 1 as the neutral element.
 Vector2 Vector2ClampValue(Vector2 v, float min, float max);
 
 // Check whether two given vectors are almost equal
 int Vector2Equals(Vector2 p, Vector2 q);
+
+// Compute the direction of a refracted ray
+// v: normalized direction of the incoming ray
+// n: normalized normal vector of the interface of two optical media
+// r: ratio of the refractive index of the medium from where the ray comes
+//    to the refractive index of the medium on the other side of the surface
+Vector2 Vector2Refract(Vector2 v, Vector2 n, float r);
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Vector3 math
@@ -348,8 +365,20 @@ Vector3 Vector3RotateByQuaternion(Vector3 v, Quaternion q);
 // Vector3Scale(wwv, 2)
 Vector3 Vector3RotateByAxisAngle(Vector3 v, Vector3 axis, float angle);
 
+// Move Vector towards target
+Vector3 Vector3MoveTowards(Vector3 v, Vector3 target, float maxDistance);
+
 // Calculate linear interpolation between two vectors
 Vector3 Vector3Lerp(Vector3 v1, Vector3 v2, float amount);
+
+// Calculate cubic hermite interpolation between two vectors and their tangents
+// as described in the GLTF 2.0 specification: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#interpolation-cubic
+Vector3 Vector3CubicHermite(
+    Vector3 v1,
+    Vector3 tangent1,
+    Vector3 v2,
+    Vector3 tangent2,
+    float amount);
 
 // Calculate reflected vector to normal
 
@@ -407,6 +436,8 @@ Vector3 Vector3Invert(Vector3 v);
 Vector3 Vector3Clamp(Vector3 v, Vector3 min, Vector3 max);
 
 // Clamp the magnitude of the vector between two values
+
+// By default, 1 as the neutral element.
 Vector3 Vector3ClampValue(Vector3 v, float min, float max);
 
 // Check whether two given vectors are almost equal
@@ -418,6 +449,66 @@ int Vector3Equals(Vector3 p, Vector3 q);
 // r: ratio of the refractive index of the medium from where the ray comes
 //    to the refractive index of the medium on the other side of the surface
 Vector3 Vector3Refract(Vector3 v, Vector3 n, float r);
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition - Vector4 math
+//----------------------------------------------------------------------------------
+
+Vector4 Vector4Zero();
+
+Vector4 Vector4One();
+
+Vector4 Vector4Add(Vector4 v1, Vector4 v2);
+
+Vector4 Vector4AddValue(Vector4 v, float add);
+
+Vector4 Vector4Subtract(Vector4 v1, Vector4 v2);
+
+Vector4 Vector4SubtractValue(Vector4 v, float add);
+
+float Vector4Length(Vector4 v);
+
+float Vector4LengthSqr(Vector4 v);
+
+float Vector4DotProduct(Vector4 v1, Vector4 v2);
+
+// Calculate distance between two vectors
+float Vector4Distance(Vector4 v1, Vector4 v2);
+
+// Calculate square distance between two vectors
+float Vector4DistanceSqr(Vector4 v1, Vector4 v2);
+
+Vector4 Vector4Scale(Vector4 v, float scale);
+
+// Multiply vector by vector
+Vector4 Vector4Multiply(Vector4 v1, Vector4 v2);
+
+// Negate vector
+Vector4 Vector4Negate(Vector4 v);
+
+// Divide vector by vector
+Vector4 Vector4Divide(Vector4 v1, Vector4 v2);
+
+// Normalize provided vector
+Vector4 Vector4Normalize(Vector4 v);
+
+// Get min value for each pair of components
+Vector4 Vector4Min(Vector4 v1, Vector4 v2);
+
+// Get max value for each pair of components
+Vector4 Vector4Max(Vector4 v1, Vector4 v2);
+
+// Calculate linear interpolation between two vectors
+Vector4 Vector4Lerp(Vector4 v1, Vector4 v2, float amount);
+
+// Move Vector towards target
+Vector4 Vector4MoveTowards(Vector4 v, Vector4 target, float maxDistance);
+
+// Invert the given vector
+Vector4 Vector4Invert(Vector4 v);
+
+// Check whether two given vectors are almost equal
+int Vector4Equals(Vector4 p, Vector4 q);
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Matrix math
@@ -498,8 +589,8 @@ Matrix MatrixFrustum(
     double right,
     double bottom,
     double top,
-    double near,
-    double far);
+    double nearPlane,
+    double farPlane);
 
 // Get perspective projection matrix
 // NOTE: Fovy angle must be provided in radians
@@ -590,6 +681,15 @@ Quaternion QuaternionNlerp(Quaternion q1, Quaternion q2, float amount);
 // Calculates spherical linear interpolation between two quaternions
 Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount);
 
+// Calculate quaternion cubic spline interpolation using Cubic Hermite Spline algorithm
+// as described in the GLTF 2.0 specification: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#interpolation-cubic
+Quaternion QuaternionCubicHermiteSpline(
+    Quaternion q1,
+    Quaternion outTangent1,
+    Quaternion q2,
+    Quaternion inTangent2,
+    float t);
+
 // Calculate quaternion based on the rotation from one vector to another
 
 // Vector3DotProduct(from, to)
@@ -642,5 +742,24 @@ Quaternion QuaternionTransform(Quaternion q, Matrix mat);
 
 // Check whether two given quaternions are almost equal
 int QuaternionEquals(Quaternion p, Quaternion q);
+
+// Decompose a transformation matrix into its rotational, translational and scaling components
+
+// Extract translation.
+
+// Extract upper-left for determinant computation
+
+// Extract scale
+
+// Remove scale from the matrix if it is not close to zero
+
+// Extract rotation
+
+// Set to identity if close to zero
+void MatrixDecompose(
+    Matrix mat,
+    Vector3* translation,
+    Quaternion* rotation,
+    Vector3* scale);
 
 // RAYMATH_H

--- a/source/raylib/raymath.d
+++ b/source/raylib/raymath.d
@@ -98,21 +98,6 @@ extern (D) auto Vector3ToFloat(T)(auto ref T vec)
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
 
-// Vector2 type
-
-// Vector3 type
-
-// Vector4 type
-
-// Quaternion type
-
-// Matrix type (OpenGL style 4x4 - right handed, column major)
-
-// Matrix first row (4 components)
-// Matrix second row (4 components)
-// Matrix third row (4 components)
-// Matrix fourth row (4 components)
-
 // NOTE: Helper types to be used instead of array return types for *ToFloat functions
 struct float3
 {

--- a/source/raylib/rcamera.d
+++ b/source/raylib/rcamera.d
@@ -64,52 +64,6 @@ enum CAMERA_CULL_DISTANCE_FAR = RL_CULL_DISTANCE_FAR;
 // NOTE: Below types are required for standalone usage
 //----------------------------------------------------------------------------------
 
-// Vector2, 2 components
-
-// Vector x component
-// Vector y component
-
-// Vector3, 3 components
-
-// Vector x component
-// Vector y component
-// Vector z component
-
-// Matrix, 4x4 components, column major, OpenGL style, right-handed
-
-// Matrix first row (4 components)
-// Matrix second row (4 components)
-// Matrix third row (4 components)
-// Matrix fourth row (4 components)
-
-// Camera type, defines a camera position/orientation in 3d space
-
-// Camera position
-// Camera target it looks-at
-// Camera up vector (rotation over its axis)
-// Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic
-// Camera projection type: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
-
-// Camera type fallback, defaults to Camera3D
-
-// Camera projection
-
-// Perspective projection
-// Orthographic projection
-
-// Camera system modes
-
-// Camera custom, controlled by user (UpdateCamera() does nothing)
-// Camera free mode
-// Camera orbital, around target, zoom supported
-// Camera first person
-// Camera third person
-
-//----------------------------------------------------------------------------------
-// Global Variables Definition
-//----------------------------------------------------------------------------------
-//...
-
 //----------------------------------------------------------------------------------
 // Module Functions Declaration
 //----------------------------------------------------------------------------------

--- a/source/raylib/rcamera.d
+++ b/source/raylib/rcamera.d
@@ -23,7 +23,7 @@ import raylib;
 *
 *   LICENSE: zlib/libpng
 *
-*   Copyright (c) 2022-2023 Christoph Wagner (@Crydsch) & Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2024 Christoph Wagner (@Crydsch) & Ramon Santamaria (@raysan5)
 *
 *   This software is provided "as-is", without any express or implied warranty. In no event
 *   will the authors be held liable for any damages arising from the use of this software.
@@ -167,13 +167,12 @@ Matrix GetCameraProjectionMatrix(Camera* camera, float aspect);
 //----------------------------------------------------------------------------------
 // Defines and Macros
 //----------------------------------------------------------------------------------
+// Units per second
 
 // Camera mouse movement sensitivity
-// TODO: it should be independant of framerate
 
+// Camera orbital speed in CAMERA_ORBITAL mode
 // Radians per second
-
-// PLAYER (used by camera)
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
@@ -301,12 +300,13 @@ Matrix GetCameraProjectionMatrix(Camera* camera, float aspect);
 // Camera rotation
 
 // Camera movement
-
 // Camera pan (for CAMERA_FREE)
 
 // Mouse support
 
 // Keyboard support
+
+// Gamepad movement
 
 // Gamepad controller support
 

--- a/source/raylib/rlgl.d
+++ b/source/raylib/rlgl.d
@@ -279,15 +279,6 @@ enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2 = 5;
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
 
-// Boolean type
-
-// Matrix, 4x4 components, column major, OpenGL style, right handed
-
-// Matrix first row (4 components)
-// Matrix second row (4 components)
-// Matrix third row (4 components)
-// Matrix fourth row (4 components)
-
 // Dynamic vertex buffers (position + texcoords + colors + indices arrays)
 struct rlVertexBuffer
 {

--- a/source/raylib/rlgl.d
+++ b/source/raylib/rlgl.d
@@ -1,9 +1,10 @@
 module raylib.rlgl;
 
 import raylib;
+
 /**********************************************************************************************
 *
-*   rlgl v4.5 - A multi-OpenGL abstraction layer with an immediate-mode style API
+*   rlgl v5.0 - A multi-OpenGL abstraction layer with an immediate-mode style API
 *
 *   DESCRIPTION:
 *       An abstraction layer for multiple OpenGL versions (1.1, 2.1, 3.3 Core, 4.3 Core, ES 2.0)
@@ -65,12 +66,12 @@ import raylib;
 *       When loading a shader, the following vertex attributes and uniform
 *       location names are tried to be set automatically:
 *
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION     "vertexPosition"    // Bound by default to shader location: 0
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD     "vertexTexCoord"    // Bound by default to shader location: 1
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL       "vertexNormal"      // Bound by default to shader location: 2
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR        "vertexColor"       // Bound by default to shader location: 3
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT      "vertexTangent"     // Bound by default to shader location: 4
-*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2    "vertexTexCoord2"   // Bound by default to shader location: 5
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION     "vertexPosition"    // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD     "vertexTexCoord"    // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL       "vertexNormal"      // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR        "vertexColor"       // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT      "vertexTangent"     // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT
+*       #define RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2    "vertexTexCoord2"   // Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2
 *       #define RL_DEFAULT_SHADER_UNIFORM_NAME_MVP         "mvp"               // model-view-projection matrix
 *       #define RL_DEFAULT_SHADER_UNIFORM_NAME_VIEW        "matView"           // view matrix
 *       #define RL_DEFAULT_SHADER_UNIFORM_NAME_PROJECTION  "matProjection"     // projection matrix
@@ -88,7 +89,7 @@ import raylib;
 *
 *   LICENSE: zlib/libpng
 *
-*   Copyright (c) 2014-2023 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
 *
 *   This software is provided "as-is", without any express or implied warranty. In no event
 *   will the authors be held liable for any damages arising from the use of this software.
@@ -109,12 +110,15 @@ import raylib;
 
 extern (C) @nogc nothrow:
 
-enum RLGL_VERSION = "4.5";
+enum RLGL_VERSION = "5.0";
 
-// Function specifiers in case library is build/used as a shared library (Windows)
+// Function specifiers in case library is build/used as a shared library
 // NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
+// NOTE: visibility(default) attribute makes symbols "visible" when compiled with -fvisibility=hidden
 
 // We are building the library as a Win32 shared library (.dll)
+
+// We are building the library as a Unix shared library (.so/.dylib)
 
 // We are using the library as a Win32 shared library (.dll)
 
@@ -254,6 +258,23 @@ enum RL_BLEND_DST_ALPHA = 0x80CA; // GL_BLEND_DST_ALPHA
 enum RL_BLEND_SRC_ALPHA = 0x80CB; // GL_BLEND_SRC_ALPHA
 enum RL_BLEND_COLOR = 0x8005; // GL_BLEND_COLOR
 
+enum RL_READ_FRAMEBUFFER = 0x8CA8; // GL_READ_FRAMEBUFFER
+enum RL_DRAW_FRAMEBUFFER = 0x8CA9; // GL_DRAW_FRAMEBUFFER
+
+// Default shader vertex attribute locations
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION = 0;
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD = 1;
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL = 2;
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR = 3;
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT = 4;
+
+enum RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2 = 5;
+
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
@@ -274,6 +295,7 @@ struct rlVertexBuffer
 
     float* vertices; // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
     float* texcoords; // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
+    float* normals; // Vertex normal (XYZ - 3 components per vertex) (shader-location = 2)
     ubyte* colors; // Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
 
     uint* indices; // Vertex indices (in case vertex data comes indexed) (6 indices per quad)
@@ -281,7 +303,7 @@ struct rlVertexBuffer
     // Vertex indices (in case vertex data comes indexed) (6 indices per quad)
 
     uint vaoId; // OpenGL Vertex Array Object id
-    uint[4] vboId; // OpenGL Vertex Buffer Objects id (4 types of vertex data)
+    uint[5] vboId; // OpenGL Vertex Buffer Objects id (5 types of vertex data)
 }
 
 // Draw call type
@@ -439,7 +461,11 @@ enum rlShaderUniformDataType
     RL_SHADER_UNIFORM_IVEC2 = 5, // Shader uniform type: ivec2 (2 int)
     RL_SHADER_UNIFORM_IVEC3 = 6, // Shader uniform type: ivec3 (3 int)
     RL_SHADER_UNIFORM_IVEC4 = 7, // Shader uniform type: ivec4 (4 int)
-    RL_SHADER_UNIFORM_SAMPLER2D = 8 // Shader uniform type: sampler2d
+    RL_SHADER_UNIFORM_UINT = 8, // Shader uniform type: unsigned int
+    RL_SHADER_UNIFORM_UIVEC2 = 9, // Shader uniform type: uivec2 (2 unsigned int)
+    RL_SHADER_UNIFORM_UIVEC3 = 10, // Shader uniform type: uivec3 (3 unsigned int)
+    RL_SHADER_UNIFORM_UIVEC4 = 11, // Shader uniform type: uivec4 (4 unsigned int)
+    RL_SHADER_UNIFORM_SAMPLER2D = 12 // Shader uniform type: sampler2d
 }
 
 // Shader attribute data types
@@ -504,6 +530,9 @@ void rlMultMatrixf(const(float)* matf); // Multiply the current matrix by anothe
 void rlFrustum(double left, double right, double bottom, double top, double znear, double zfar);
 void rlOrtho(double left, double right, double bottom, double top, double znear, double zfar);
 void rlViewport(int x, int y, int width, int height); // Set the viewport area
+void rlSetClipPlanes(double nearPlane, double farPlane); // Set clip planes distances
+double rlGetCullDistanceNear(); // Get cull plane distance near
+double rlGetCullDistanceFar(); // Get cull plane distance far
 
 //------------------------------------------------------------------------------------
 // Functions Declaration - Vertex level operations
@@ -554,8 +583,10 @@ void rlDisableShader(); // Disable shader program
 // Framebuffer state
 void rlEnableFramebuffer(uint id); // Enable render texture (fbo)
 void rlDisableFramebuffer(); // Disable render texture (fbo), return to default framebuffer
+uint rlGetActiveFramebuffer(); // Get the currently active render texture (fbo), 0 for default framebuffer
 void rlActiveDrawBuffers(int count); // Activate multiple draw color buffers
 void rlBlitFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY, int dstWidth, int dstHeight, int bufferMask); // Blit active framebuffer to main framebuffer
+void rlBindFramebuffer(uint target, uint framebuffer); // Bind framebuffer (FBO)
 
 // General render state
 void rlEnableColorBlend(); // Enable color blending
@@ -566,13 +597,14 @@ void rlEnableDepthMask(); // Enable depth write
 void rlDisableDepthMask(); // Disable depth write
 void rlEnableBackfaceCulling(); // Enable backface culling
 void rlDisableBackfaceCulling(); // Disable backface culling
+void rlColorMask(bool r, bool g, bool b, bool a); // Color mask control
 void rlSetCullFace(int mode); // Set face culling mode
 void rlEnableScissorTest(); // Enable scissor test
 void rlDisableScissorTest(); // Disable scissor test
 void rlScissor(int x, int y, int width, int height); // Scissor test
 void rlEnableWireMode(); // Enable wire mode
-void rlEnablePointMode(); //  Enable point mode
-void rlDisableWireMode(); // Disable wire mode ( and point ) maybe rename
+void rlEnablePointMode(); // Enable point mode
+void rlDisableWireMode(); // Disable wire (and point) mode
 void rlSetLineWidth(float width); // Set the line drawing width
 float rlGetLineWidth(); // Get the line drawing width
 void rlEnableSmoothLines(); // Enable line aliasing
@@ -621,25 +653,25 @@ void rlSetTexture(uint id); // Set current texture for render batch and check bu
 
 // Vertex buffers management
 uint rlLoadVertexArray(); // Load vertex array (vao) if supported
-uint rlLoadVertexBuffer(const(void)* buffer, int size, bool dynamic); // Load a vertex buffer attribute
-uint rlLoadVertexBufferElement(const(void)* buffer, int size, bool dynamic); // Load a new attributes element buffer
-void rlUpdateVertexBuffer(uint bufferId, const(void)* data, int dataSize, int offset); // Update GPU buffer with new data
-void rlUpdateVertexBufferElements(uint id, const(void)* data, int dataSize, int offset); // Update vertex buffer elements with new data
-void rlUnloadVertexArray(uint vaoId);
-void rlUnloadVertexBuffer(uint vboId);
-void rlSetVertexAttribute(uint index, int compSize, int type, bool normalized, int stride, const(void)* pointer);
-void rlSetVertexAttributeDivisor(uint index, int divisor);
-void rlSetVertexAttributeDefault(int locIndex, const(void)* value, int attribType, int count); // Set vertex attribute default value
-void rlDrawVertexArray(int offset, int count);
-void rlDrawVertexArrayElements(int offset, int count, const(void)* buffer);
-void rlDrawVertexArrayInstanced(int offset, int count, int instances);
-void rlDrawVertexArrayElementsInstanced(int offset, int count, const(void)* buffer, int instances);
+uint rlLoadVertexBuffer(const(void)* buffer, int size, bool dynamic); // Load a vertex buffer object
+uint rlLoadVertexBufferElement(const(void)* buffer, int size, bool dynamic); // Load vertex buffer elements object
+void rlUpdateVertexBuffer(uint bufferId, const(void)* data, int dataSize, int offset); // Update vertex buffer object data on GPU buffer
+void rlUpdateVertexBufferElements(uint id, const(void)* data, int dataSize, int offset); // Update vertex buffer elements data on GPU buffer
+void rlUnloadVertexArray(uint vaoId); // Unload vertex array (vao)
+void rlUnloadVertexBuffer(uint vboId); // Unload vertex buffer object
+void rlSetVertexAttribute(uint index, int compSize, int type, bool normalized, int stride, int offset); // Set vertex attribute data configuration
+void rlSetVertexAttributeDivisor(uint index, int divisor); // Set vertex attribute data divisor
+void rlSetVertexAttributeDefault(int locIndex, const(void)* value, int attribType, int count); // Set vertex attribute default value, when attribute to provided
+void rlDrawVertexArray(int offset, int count); // Draw vertex array (currently active vao)
+void rlDrawVertexArrayElements(int offset, int count, const(void)* buffer); // Draw vertex array elements
+void rlDrawVertexArrayInstanced(int offset, int count, int instances); // Draw vertex array (currently active vao) with instancing
+void rlDrawVertexArrayElementsInstanced(int offset, int count, const(void)* buffer, int instances); // Draw vertex array elements with instancing
 
 // Textures management
-uint rlLoadTexture(const(void)* data, int width, int height, int format, int mipmapCount); // Load texture in GPU
+uint rlLoadTexture(const(void)* data, int width, int height, int format, int mipmapCount); // Load texture data
 uint rlLoadTextureDepth(int width, int height, bool useRenderBuffer); // Load depth texture/renderbuffer (to be attached to fbo)
-uint rlLoadTextureCubemap(const(void)* data, int size, int format); // Load texture cubemap
-void rlUpdateTexture(uint id, int offsetX, int offsetY, int width, int height, int format, const(void)* data); // Update GPU texture with new data
+uint rlLoadTextureCubemap(const(void)* data, int size, int format); // Load texture cubemap data
+void rlUpdateTexture(uint id, int offsetX, int offsetY, int width, int height, int format, const(void)* data); // Update texture with new data on GPU
 void rlGetGlTextureFormats(int format, uint* glInternalFormat, uint* glFormat, uint* glType); // Get OpenGL internal formats
 const(char)* rlGetPixelFormatName(uint format); // Get name string for pixel format
 void rlUnloadTexture(uint id); // Unload texture from GPU memory
@@ -648,7 +680,7 @@ void* rlReadTexturePixels(uint id, int width, int height, int format); // Read t
 ubyte* rlReadScreenPixels(int width, int height); // Read screen pixel data (color buffer)
 
 // Framebuffer management (fbo)
-uint rlLoadFramebuffer(int width, int height); // Load an empty framebuffer
+uint rlLoadFramebuffer(); // Load an empty framebuffer
 void rlFramebufferAttach(uint fboId, uint texId, int attachType, int texType, int mipLevel); // Attach texture/renderbuffer to a framebuffer
 bool rlFramebufferComplete(uint id); // Verify framebuffer is complete
 void rlUnloadFramebuffer(uint id); // Delete framebuffer from GPU
@@ -704,6 +736,8 @@ void rlLoadDrawQuad(); // Load and draw a quad
 *
 ************************************************************************************/
 
+// Expose OpenGL functions from glad in raylib
+
 // OpenGL 1.1 library for OSX
 // OpenGL extensions library
 
@@ -719,7 +753,7 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // OpenGL ES 2.0 extensions library
 
-// NOTE: OpenGL ES 2.0 can be enabled on PLATFORM_DESKTOP,
+// NOTE: OpenGL ES 2.0 can be enabled on Desktop platforms,
 // in that case, functions are loaded from a custom glad for OpenGL ES 2.0
 
 //#include <EGL/egl.h>          // EGL library -> not required, platform layer
@@ -739,17 +773,17 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Default shader vertex attribute names to set location points
 
-// Bound by default to shader location: 0
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION
 
-// Bound by default to shader location: 1
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD
 
-// Bound by default to shader location: 2
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL
 
-// Bound by default to shader location: 3
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR
 
-// Bound by default to shader location: 4
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT
 
-// Bound by default to shader location: 5
+// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2
 
 // model-view-projection matrix
 
@@ -871,8 +905,13 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // Get pixel data size in bytes (image or texture)
 
 // Auxiliar matrix math functions
+
+// Get float array of matrix data
+// Get float vector for Matrix
 // Get identity matrix
 // Multiply two matrices
+// Transposes provided matrix
+// Invert provided matrix
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Matrix operations
@@ -922,6 +961,12 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // Set the viewport area (transformation from normalized device coordinates to window coordinates)
 // NOTE: We store current viewport dimensions
 
+// Set clip planes distances
+
+// Get cull plane distance near
+
+// Get cull plane distance far
+
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Vertex level operations
 //----------------------------------------------------------------------------------
@@ -963,7 +1008,7 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Add current texcoord
 
-// WARNING: By default rlVertexBuffer struct does not store normals
+// Add current normal
 
 // Add current color
 
@@ -1021,9 +1066,13 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Enable rendering to texture (fbo)
 
+// return the active render texture (fbo)
+
 // Disable rendering to texture
 
 // Blit active framebuffer to main framebuffer
+
+// Bind framebuffer object (fbo)
 
 // Activate multiple draw color buffers
 // NOTE: One color buffer is always active by default
@@ -1053,6 +1102,8 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Disable backface culling
 
+// Set color mask active for screen read/draw
+
 // Set face culling mode
 
 // Enable scissor test
@@ -1064,6 +1115,8 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // Enable wire mode
 
 // NOTE: glPolygonMode() not available on OpenGL ES
+
+// Enable point mode
 
 // NOTE: glPolygonMode() not available on OpenGL ES
 
@@ -1140,6 +1193,7 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // Loaded: RLGL.State.defaultShaderId + RLGL.State.defaultShaderLocs
 
 // Init default vertex arrays buffers
+// Simulate that the default shader has the location RL_SHADER_LOC_VERTEX_NORMAL to bind the normal buffer for the default render batch
 
 // Init stack matrices (emulating OpenGL 1.1)
 
@@ -1322,6 +1376,7 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // 3 float by vertex, 4 vertex by quad
 // 2 float by texcoord, 4 texcoord by quad
+// 3 float by vertex, 4 vertex by quad
 // 4 float by color, 4 colors by quad
 
 // 6 int by quad (indices)
@@ -1341,6 +1396,8 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // Vertex position buffer (shader-location = 0)
 
 // Vertex texcoord buffer (shader-location = 1)
+
+// Vertex normal buffer (shader-location = 2)
 
 // Vertex color buffer (shader-location = 3)
 
@@ -1398,6 +1455,10 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 //glBufferData(GL_ARRAY_BUFFER, sizeof(float)*2*4*batch->vertexBuffer[batch->currentBuffer].elementCount, batch->vertexBuffer[batch->currentBuffer].texcoords, GL_DYNAMIC_DRAW); // Update all buffer
 
+// Normals buffer
+
+//glBufferData(GL_ARRAY_BUFFER, sizeof(float)*3*4*batch->vertexBuffer[batch->currentBuffer].elementCount, batch->vertexBuffer[batch->currentBuffer].normals, GL_DYNAMIC_DRAW); // Update all buffer
+
 // Colors buffer
 
 //glBufferData(GL_ARRAY_BUFFER, sizeof(float)*4*4*batch->vertexBuffer[batch->currentBuffer].elementCount, batch->vertexBuffer[batch->currentBuffer].colors, GL_DYNAMIC_DRAW);    // Update all buffer
@@ -1436,9 +1497,14 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Create modelview-projection matrix and upload to shader
 
+// WARNING: For the following setup of the view, model, and normal matrices, it is expected that
+// transformations and rendering occur between rlPushMatrix and rlPopMatrix.
+
 // Bind vertex attrib: position (shader-location = 0)
 
 // Bind vertex attrib: texcoord (shader-location = 1)
+
+// Bind vertex attrib: normal (shader-location = 2)
 
 // Bind vertex attrib: color (shader-location = 3)
 
@@ -1728,6 +1794,11 @@ void rlLoadDrawQuad(); // Load and draw a quad
 
 // Set vertex attribute
 
+// NOTE: Data type could be: GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT, GL_UNSIGNED_SHORT, GL_INT, GL_UNSIGNED_INT
+// Additional types (depends on OpenGL version or extensions):
+//  - GL_HALF_FLOAT, GL_FLOAT, GL_DOUBLE, GL_FIXED,
+//  - GL_INT_2_10_10_10_REV, GL_UNSIGNED_INT_2_10_10_10_REV, GL_UNSIGNED_INT_10F_11F_11F_REV
+
 // Set vertex attribute divisor
 
 // Unload vertex array object (VAO)
@@ -1742,12 +1813,10 @@ void rlLoadDrawQuad(); // Load and draw a quad
 // NOTE: If shader string is NULL, using default vertex/fragment shaders
 
 // Compile vertex shader (if provided)
-
-// In case no vertex shader was provided or compilation failed, we use default vertex shader
+// NOTE: If not vertex shader is provided, use default one
 
 // Compile fragment shader (if provided)
-
-// In case no fragment shader was provided or compilation failed, we use default fragment shader
+// NOTE: If not vertex shader is provided, use default one
 
 // In case vertex and fragment shader are the default ones, no need to recompile, we can just assign the default shader program id
 
@@ -1820,6 +1889,8 @@ else
 //else TRACELOG(RL_LOG_INFO, "SHADER: [ID %i] Shader attribute (%s) set at location: %i", shaderId, attribName, location);
 
 // Set shader value uniform
+
+// TODO: Support glUniform1uiv(), glUniform2uiv(), glUniform3uiv(), glUniform4uiv()
 
 // Set shader value attribute
 
@@ -1968,9 +2039,13 @@ else
 
 // Vertex shader directly defined, no external file required
 
+// Precision required for OpenGL ES3 (WebGL 2) (on some browsers)
+
 // Precision required for OpenGL ES2 (WebGL) (on some browsers)
 
 // Fragment shader directly defined, no external file required
+
+// Precision required for OpenGL ES3 (WebGL 2)
 
 // Precision required for OpenGL ES2 (WebGL)
 
@@ -2021,9 +2096,19 @@ else
 
 // Auxiliar math functions
 
+// Get float array of matrix data
+
 // Get identity matrix
 
 // Get two matrix multiplication
 // NOTE: When multiplying matrices... the order matters!
+
+// Transposes provided matrix
+
+// Invert provided matrix
+
+// Cache the matrix values (speed optimization)
+
+// Calculate the invert determinant (inlined to avoid double-caching)
 
 // RLGL_IMPLEMENTATION


### PR DESCRIPTION
Hi. I have made (or at least tried) that the raylib modules are updated to version 5.5-dev.

As for the `lib.tgz` file, although I stored the .so of raylib 5.5-dev (only for Linux) in this one, I have had problems when executing `dub run raylib-d:install`, because I got an error that although it decompresses the file, it does it halfway because an important file is missing.

Finally, I updated the `install` package dependencies to their latest versions until now. I have already even tried with the `LoadImageAnimFromMemory` function and in my experience, it works.

PS: The commits named “source/raylib/raylib” were due to a confusion I made.