### PR TITLE
Add zlib as a link directive on posix systems for the install script.

### DIFF
--- a/install/dub.json
+++ b/install/dub.json
@@ -9,6 +9,7 @@
         "io": "~>0.3.4",
         "getopt2": "0.0.1"
     },
+    "libs-posix" : ["z"],
     "description": "Install raylib binary files",
     "license": "boost-1.0",
     "name": "install"


### PR DESCRIPTION
This technically should be provided by phobos, but on some default os packages, zlib is not included with phobos, and you must explicitly link against it.